### PR TITLE
use tox with Python 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 
 language: python
 python:
-  - 3.7
   - 3.6
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@
 
 language: python
 python:
+  - 3.7
   - 3.6
-  - 3.5
-  - 3.4
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py34, py35, py36, flake8
+envlist = py36, py37, flake8
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
-    3.5: py35
-    3.4: py34
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
Python 3.5 cannot be tested as the black package requires Python 3.6 or higher.